### PR TITLE
updated user authentication for CRUD

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -1,4 +1,6 @@
 class ProductsController < ApplicationController
+  before_action :authenticate_user!, except: [:show, :index]
+
   def index
     @products = Product.all
   end
@@ -40,14 +42,9 @@ class ProductsController < ApplicationController
   end
 
   def destroy
-    if current_user
-      Product.find(params[:id]).destroy
-      flash[:success] = 'Product Deleted'
-      redirect_to products_path
-    else
-      flash[:warning] = 'You must be signed in.'
-      redirect_to products_path
-    end
+    Product.find(params[:id]).destroy
+    flash[:success] = 'Product Deleted'
+    redirect_to products_path
   end
 
   protected

--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -1,4 +1,6 @@
 class ReviewsController < ApplicationController
+  before_action :authenticate_user!, except: [:show, :index]
+
   def create
     @user = current_user
     @product = Product.find(params[:product_id])
@@ -9,10 +11,10 @@ class ReviewsController < ApplicationController
     if @review.save
       flash[:notice] = 'Review successfully added'
       redirect_to product_path(@product)
-    elsif
-      @review.errors.full_messages.join(' ').include?('User')
-      flash[:error] = 'You must be signed in'
-      redirect_to product_path(@product)
+    # elsif
+      # @review.errors.full_messages.join(' ').include?('User')
+      # flash[:error] = 'You must be signed in'
+      # redirect_to product_path(@product)
     else
       flash[:error] = @review.errors.full_messages.join(' ')
       redirect_to product_path(@product)
@@ -20,9 +22,7 @@ class ReviewsController < ApplicationController
   end
 
   protected
-
   def review_params
-    params.require(:review).permit(:title, :body, :product, :product_fit,
-                    :user_id, :product_id)
+    params.require(:review).permit(:title, :body, :product_fit)
   end
 end

--- a/spec/features/user_adds_new_product_spec.rb
+++ b/spec/features/user_adds_new_product_spec.rb
@@ -36,4 +36,9 @@ feature 'user adds new product', %{
     expect(page).to have_content('Add a new product!')
     expect(page).to have_content('Title can\'t be blank')
   end
+
+  scenario 'user is not signed in' do
+    visit new_product_path
+    expect(page).to have_content('You need to sign in or sign up before continuing.')
+  end
 end

--- a/spec/features/user_adds_review_of_a_product_spec.rb
+++ b/spec/features/user_adds_review_of_a_product_spec.rb
@@ -39,13 +39,13 @@ feature 'user adds review of a product', %{
     end
   end
 
-  scenario 'Non-user tries to review product' do
+  scenario 'user is not signed in' do
     visit product_path(product)
     fill_in 'Title', with: 'My Review'
     fill_in 'Body', with: 'This doesn\'t fit!'
     fill_in 'Product fit', with: 3
     click_button 'Create Review'
-    expect(page).to have_no_content('Review successfully added')
-    expect(page).to have_content('You must be signed in')
+    expect(page).to_not have_content('Review successfully added')
+    expect(page).to have_content('You need to sign in or sign up before continuing.')
   end
 end

--- a/spec/features/user_deletes_product_spec.rb
+++ b/spec/features/user_deletes_product_spec.rb
@@ -26,6 +26,6 @@ feature 'deletes product', %{
     visit product_path(product)
     click_link 'Delete Product'
     expect(page).to have_no_content('Product Deleted')
-    expect(page).to have_content('You must be signed in.')
+    expect(page).to have_content('You need to sign in or sign up before continuing.')
   end
 end

--- a/spec/features/user_updates_product_spec.rb
+++ b/spec/features/user_updates_product_spec.rb
@@ -33,4 +33,11 @@ feature 'user updates a product', %{
     expect(page).to have_content('Edit Product!')
     expect(page).to have_content('Title can\'t be blank')
   end
+
+  scenario 'user is not signed in' do
+    visit product_path(product)
+    click_link 'Edit Product Info'
+    expect(page).to_not have_content('Product Deleted')
+    expect(page).to have_content('You need to sign in or sign up before continuing.')
+  end
 end


### PR DESCRIPTION
We used before_action :authenticate_user! to implement constraints on 
who can update, create, and destroy items. (Both products and reviews)
